### PR TITLE
Typos and suggestion

### DIFF
--- a/docs/docs/modules/model/pages/_partials/MathNotations.adoc
+++ b/docs/docs/modules/model/pages/_partials/MathNotations.adoc
@@ -11,6 +11,6 @@ By abuse we will use only stem:[\nabla] and not stem:[{\nabla }]
 == Space Functions
 
 * stem:[L_{2}(\Omega)] : stem:[\{f  \mid \int f^{2} < \infty\}]
-* stem:[H_{1}(\Omega)$] : stem:[\{f \in L_{2}(\Omega) \mid \nabla f \in [L_{2}(\Omega)]}]
+* stem:[H_{1}(\Omega)] : stem:[\{f \in L_{2}(\Omega) \mid \nabla f \in [L_{2}(\Omega)]\}]
 * stem:[H_{div}(\Omega)] : stem:[\{\mathbf{f}\in [L^{2} (\Omega)] | \nabla.\mathbf{f}\in L^{2}(\Omega)\}]
 * stem:[H_{curl}(\Omega)] : stem:[\{\mathbf{f}\in [L^{2} (\Omega)] | \nabla\times\mathbf{f}\in [L^{2} (\Omega)]^{d}\}]


### PR DESCRIPTION
Not clear the difference : 
By abuse we will use only ∇ and not ∇