### PR TITLE
Update scratch.adoc

### DIFF
--- a/docs/docs/modules/dev/pages/cad/scratch.adoc
+++ b/docs/docs/modules/dev/pages/cad/scratch.adoc
@@ -57,6 +57,7 @@ On Windows 10 Pro you have to:
 * install Debian/Stretch from Windows Store,
 
 To install {salome} in WSL Debian/Stretch:
+
 * start Debian
 * setup lncmi debian repository
 * install {salome} binary for Debian/Stretch in Debian WSL.


### PR DESCRIPTION
Typo : il manquait un saut de ligne pour créer une liste.